### PR TITLE
chore: use patched version of @xmldom/xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "standard-version": "^9.1.1"
   },
   "resolutions": {
-    "@xmldom/xmldom": "<=0.8.4"
+    "@xmldom/xmldom": "^0.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "jsii": "^1.70.0",
     "jsii-pacmak": "^1.70.0",
     "standard-version": "^9.1.1"
+  },
+  "resolutions": {
+    "@xmldom/xmldom": "<=0.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@xmldom/xmldom@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.3.tgz#beaf980612532aa9a3004aff7e428943aeaa0711"
-  integrity sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==
+"@xmldom/xmldom@<=0.8.4", "@xmldom/xmldom@^0.8.3":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.4.tgz#05b76034d3e09d4b9d309d9b862994de23e7687d"
+  integrity sha512-JIsjTbWBWJHb2t1D4UNZIJ6ohlRYCdoGzeHSzTorMH2zOq3UKlSBzFBMBdFK3xnUD/ANHw/SUzl/vx0z0JrqRw==
 
 JSONStream@^1.0.4:
   version "1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@xmldom/xmldom@<=0.8.4", "@xmldom/xmldom@^0.8.3":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.4.tgz#05b76034d3e09d4b9d309d9b862994de23e7687d"
-  integrity sha512-JIsjTbWBWJHb2t1D4UNZIJ6ohlRYCdoGzeHSzTorMH2zOq3UKlSBzFBMBdFK3xnUD/ANHw/SUzl/vx0z0JrqRw==
+"@xmldom/xmldom@^0.8.3", "@xmldom/xmldom@^0.8.4":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
+  integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
## Summary

There was a security vulnerability reported in the peer dependency `@xmldom/xmldom`. This PR requires use of a secure version `0.8.4` or higher.

[Security vulnerability report](https://security.snyk.io/package/npm/@xmldom%2Fxmldom/0.8.3)

TT: D64018268